### PR TITLE
Add worktree-aware git refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Compact, clickable, customizable statusline for [Claude Code](https://claude.ai/
 - **Custom items** — add your own shell-driven statusline segments with caching and conditional display
 - **Per-repo items** — `.clickline` file for repo-local service links (Railway, Vercel, Supabase, etc.), shareable via git
 - **Interactive configurator** — TUI (Textual) or bash wizard to choose elements, theme, and layout
-- **Smart truncation** — long paths show last 2 segments, branch names cap at 25 chars
+- **Smart truncation** — long paths show last 2 segments, branch/ref names cap at 25 chars
 - **PR + CI** — open PR number (clickable), "New PR" shortcut, CI status ✓ ✗ ⋯ (all async, never blocks)
 - **Quota tracking** — 5-hour and 7-day usage with time-until-reset, cached and stale-while-revalidated
 - **Context window** — percentage + max size, with ⚠️ / 🚨 warnings at 60% and 80%
@@ -128,7 +128,7 @@ Falls back to the bash wizard if Textual is unavailable.
 | Element | Destination |
 |---|---|
 | Working directory | `file://` — opens in Finder / VS Code / Cursor |
-| Git branch | `https://github.com/owner/repo/tree/branch` |
+| Git branch/ref | `https://github.com/owner/repo/tree/branch` |
 | PR `#N` | Pull request page |
 | `New PR` | GitHub compare page to open a PR |
 | CI symbol (✓ ✗ ⋯) | GitHub Actions run page |

--- a/statusline.sh
+++ b/statusline.sh
@@ -12,7 +12,7 @@ input=$(cat)
 eval "$(echo "$input" | jq -r '
   @sh "model=\(.model.display_name // "—")",
   @sh "model_id=\(.model.id // "—")",
-  @sh "dir=\(.workspace.current_dir // "—")",
+  @sh "dir=\(.workspace.current_dir // "")",
   @sh "used=\(.context_window.used_percentage // "")",
   @sh "ctx_size=\(.context_window.context_window_size // 200000)",
   @sh "cost=\(.cost.total_cost_usd // 0)",
@@ -173,14 +173,71 @@ short_dir=$(echo "$dir" | awk -F/ -v n="$_ps" '
 _md5() { printf '%s' "$1" | md5 2>/dev/null || printf '%s' "$1" | md5sum 2>/dev/null | cut -d' ' -f1; }
 
 # ── Git info ──────────────────────────────────────────────────────────────────
-git_branch_full=$(git -C "$dir" symbolic-ref --short HEAD 2>/dev/null)
-git_branch="$git_branch_full"
+github_remote_url() {
+  local remote="$1"
+  case "$remote" in
+    git@github.com:*)       printf 'https://github.com/%s' "${remote#git@github.com:}" | sed 's|\.git$||' ;;
+    ssh://git@github.com/*) printf 'https://github.com/%s' "${remote#ssh://git@github.com/}" | sed 's|\.git$||' ;;
+    https://github.com/*)   printf '%s' "$remote" | sed 's|\.git$||' ;;
+  esac
+}
+
+github_repo_path() {
+  local url="$1"
+  [ -n "$url" ] && printf '%s' "${url#https://github.com/}"
+}
+
+git_branch_full=""
+git_branch_ref=""
+git_ref_url=""
+repo_path=""
+github_branch_url=""
+git_root=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)
+
+if [ -n "$git_root" ]; then
+  git_branch_full=$(git -C "$dir" branch --show-current 2>/dev/null)
+  if [ -n "$git_branch_full" ]; then
+    git_branch_ref="$git_branch_full"
+    _git_upstream=$(git -C "$dir" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null)
+    if [ -n "$_git_upstream" ]; then
+      _git_remote_name=${_git_upstream%%/*}
+      _git_remote_branch=${_git_upstream#*/}
+      if [ -n "$_git_remote_name" ] && [ "$_git_remote_branch" != "$_git_upstream" ]; then
+        _git_remote=$(git -C "$dir" config --get "remote.$_git_remote_name.url" 2>/dev/null)
+        _github_remote=$(github_remote_url "$_git_remote")
+        if [ -n "$_github_remote" ]; then
+          repo_path=$(github_repo_path "$_github_remote")
+          git_ref_url="$_git_remote_branch"
+          github_branch_url="${_github_remote}/tree/${git_ref_url}"
+        fi
+      fi
+    fi
+  else
+    git_ref_url=$(git -C "$dir" rev-parse --short HEAD 2>/dev/null)
+    [ -n "$git_ref_url" ] && git_branch_ref="detached@$git_ref_url"
+    _git_remote=$(git -C "$dir" config --get remote.origin.url 2>/dev/null)
+    _github_remote=$(github_remote_url "$_git_remote")
+    if [ -n "$_github_remote" ]; then
+      repo_path=$(github_repo_path "$_github_remote")
+      github_branch_url="${_github_remote}/tree/${git_ref_url}"
+    fi
+  fi
+
+  if [ -z "$repo_path" ]; then
+    _git_remote=$(git -C "$dir" config --get remote.origin.url 2>/dev/null)
+    _github_remote=$(github_remote_url "$_git_remote")
+    [ -n "$_github_remote" ] && repo_path=$(github_repo_path "$_github_remote")
+  fi
+fi
+
+git_branch="$git_branch_ref"
+git_branch_placeholder="${git_branch_full:-$git_branch_ref}"
+git_branch_remote_ref="${git_ref_url:-$git_branch_full}"
 _max_b=${BRANCH_MAX_CHARS:-25}
 if [ -n "$git_branch" ] && [ "${#git_branch}" -gt "$_max_b" ]; then
   git_branch="${git_branch:0:$(( _max_b - 1 ))}…"
 fi
 
-git_root=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)
 repo_hash=$(_md5 "${git_root:-$dir}")
 
 # ── Custom items (merged: repo-local .clickline overrides global) ────────────
@@ -195,16 +252,6 @@ elif [ -n "$_cr" ]; then
   _custom_merged="$_cr"
 elif [ -n "$_cg" ]; then
   _custom_merged="$_cg"
-fi
-
-repo_path=""
-github_branch_url=""
-if [ -n "$git_branch_full" ]; then
-  _git_remote=$(git -C "$dir" remote get-url origin 2>/dev/null)
-  if [ -n "$_git_remote" ]; then
-    repo_path=$(echo "$_git_remote" | sed 's|git@github.com:||; s|https://github.com/||; s|\.git$||')
-    github_branch_url="https://github.com/${repo_path}/tree/${git_branch_full}"
-  fi
 fi
 
 default_branch=$(git -C "$dir" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|origin/||')
@@ -254,7 +301,7 @@ if [ "${SHOW_PR:-true}" = "true" ] \
     if [ $(( now_epoch - _cache_ts )) -gt "${PR_CACHE_TTL:-60}" ]; then
       # stale: serve cached, refresh in background
       ( _tmp=$(mktemp /tmp/.clickline-pr-XXXXXX)
-        if (cd "$dir" && gh pr view --json url,number >"$_tmp" 2>/dev/null); then
+        if (cd "$dir" && gh pr view --repo "$repo_path" --json url,number >"$_tmp" 2>/dev/null); then
           printf '%s %s\n' "$(date +%s)" "$(jq -c '.' "$_tmp")" > "$PR_CACHE"
         fi
         rm -f "$_tmp" ) &
@@ -263,7 +310,7 @@ if [ "${SHOW_PR:-true}" = "true" ] \
   else
     # cold cache: fire async, show nothing this render
     ( _tmp=$(mktemp /tmp/.clickline-pr-XXXXXX)
-      if (cd "$dir" && gh pr view --json url,number >"$_tmp" 2>/dev/null); then
+      if (cd "$dir" && gh pr view --repo "$repo_path" --json url,number >"$_tmp" 2>/dev/null); then
         printf '%s %s\n' "$(date +%s)" "$(jq -c '.' "$_tmp")" > "$PR_CACHE"
       else
         printf '%s {}\n' "$(date +%s)" > "$PR_CACHE"
@@ -276,7 +323,7 @@ if [ "${SHOW_PR:-true}" = "true" ] \
     _branch_enc=$(python3 -c "
 import urllib.parse, sys
 print(urllib.parse.quote(sys.argv[1], safe='/'))
-" "$git_branch_full" 2>/dev/null || printf '%s' "$git_branch_full")
+" "$git_branch_remote_ref" 2>/dev/null || printf '%s' "$git_branch_remote_ref")
     pr_new_url="https://github.com/${repo_path}/compare/${_branch_enc}?expand=1"
   fi
 fi
@@ -285,10 +332,11 @@ fi
 ci_status=""
 ci_conclusion=""
 ci_url=""
-CI_CACHE="/tmp/.clickline-ci-${repo_hash}-$(_md5 "${git_branch_full:-nobranch}")"
+CI_CACHE="/tmp/.clickline-ci-${repo_hash}-$(_md5 "${git_branch_remote_ref:-nobranch}")"
 
 if [ "${SHOW_CI:-false}" = "true" ] \
-   && [ -n "$git_branch_full" ] \
+   && [ -n "$git_branch_remote_ref" ] \
+   && [ -n "$repo_path" ] \
    && command -v gh >/dev/null 2>&1; then
 
   if [ -f "$CI_CACHE" ]; then
@@ -296,7 +344,7 @@ if [ "${SHOW_CI:-false}" = "true" ] \
     _ci_data=$(cut -d' ' -f2- "$CI_CACHE")
     if [ $(( now_epoch - _cache_ts )) -gt "${CI_CACHE_TTL:-30}" ]; then
       ( _tmp=$(mktemp /tmp/.clickline-ci-XXXXXX)
-        if (cd "$dir" && gh run list --branch "$git_branch_full" --limit 1 \
+        if (cd "$dir" && gh run list --repo "$repo_path" --branch "$git_branch_remote_ref" --limit 1 \
             --json status,conclusion,url >"$_tmp" 2>/dev/null); then
           printf '%s %s\n' "$(date +%s)" "$(jq -c '.' "$_tmp")" > "$CI_CACHE"
         fi
@@ -310,7 +358,7 @@ if [ "${SHOW_CI:-false}" = "true" ] \
     ' 2>/dev/null)"
   else
     ( _tmp=$(mktemp /tmp/.clickline-ci-XXXXXX)
-      if (cd "$dir" && gh run list --branch "$git_branch_full" --limit 1 \
+      if (cd "$dir" && gh run list --repo "$repo_path" --branch "$git_branch_remote_ref" --limit 1 \
           --json status,conclusion,url >"$_tmp" 2>/dev/null); then
         printf '%s %s\n' "$(date +%s)" "$(jq -c '.' "$_tmp")" > "$CI_CACHE"
       fi
@@ -662,7 +710,7 @@ render_element() {
       # Get link
       local _link; _link=$(printf '%s' "$_def" | jq -r '.link // ""' 2>/dev/null)
       _link="${_link//\{dir\}/$dir}"
-      _link="${_link//\{branch\}/$git_branch_full}"
+      _link="${_link//\{branch\}/$git_branch_placeholder}"
       printf '%s' "$_cc"
       if [ -n "$_link" ]; then
         osc_url "$_link" "$_label"

--- a/test/git-worktree.sh
+++ b/test/git-worktree.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/clickline-git-test.XXXXXX")
+trap 'rm -rf "$TMPDIR"' EXIT
+
+export HOME="$TMPDIR/home"
+mkdir -p "$HOME/.claude"
+cat > "$HOME/.claude/clickline.conf" <<'CONF'
+LAYOUT='path branch'
+SHOW_QUOTA=false
+SHOW_PR=false
+SHOW_CI=false
+SHOW_COMMIT=false
+SHOW_DIRTY=false
+CONF
+
+FAKEBIN="$TMPDIR/bin"
+mkdir -p "$FAKEBIN"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$FAKEBIN/security"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$FAKEBIN/curl"
+chmod +x "$FAKEBIN/security" "$FAKEBIN/curl"
+export PATH="$FAKEBIN:$PATH"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    printf 'FAIL: %s\nExpected output to contain: %s\n' "$label" "$needle" >&2
+    return 1
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    printf 'FAIL: %s\nExpected output not to contain: %s\n' "$label" "$needle" >&2
+    return 1
+  fi
+}
+
+statusline_json() {
+  local dir="$1"
+  jq -n --arg dir "$dir" '{
+    model: {display_name: "Test Model", id: "test"},
+    workspace: {current_dir: $dir},
+    context_window: {used_percentage: 1, context_window_size: 200000},
+    cost: {total_cost_usd: 0, total_duration_ms: 1000},
+    version: "test"
+  }'
+}
+
+run_statusline() {
+  local dir="$1"
+  bash "$ROOT/statusline.sh" <<<"$(statusline_json "$dir")"
+}
+
+repo="$TMPDIR/repo"
+mkdir -p "$repo"
+git -C "$repo" init -q
+git -C "$repo" config user.email test@example.com
+git -C "$repo" config user.name "Test User"
+printf 'hello\n' > "$repo/file.txt"
+git -C "$repo" add file.txt
+git -C "$repo" commit -qm initial
+git -C "$repo" remote add origin git@github.com:example/project.git
+
+default_branch=$(git -C "$repo" branch --show-current)
+git -C "$repo" update-ref "refs/remotes/origin/$default_branch" HEAD
+git -C "$repo" branch --set-upstream-to="origin/$default_branch" "$default_branch" >/dev/null
+output=$(run_statusline "$repo")
+assert_contains "$output" "$default_branch" "normal repository branch"
+assert_contains "$output" "https://github.com/example/project/tree/$default_branch" "normal repository GitHub link"
+printf 'ok - normal repository branch\n'
+
+linked="$TMPDIR/linked"
+git -C "$repo" worktree add -q -b feature/linked "$linked"
+git -C "$linked" update-ref refs/remotes/origin/feature/linked HEAD
+git -C "$linked" branch --set-upstream-to=origin/feature/linked feature/linked >/dev/null
+output=$(run_statusline "$linked")
+assert_contains "$output" "feature/linked" "linked worktree branch"
+assert_contains "$output" "https://github.com/example/project/tree/feature/linked" "linked worktree GitHub link"
+printf 'ok - linked worktree branch\n'
+
+renamed="$TMPDIR/renamed"
+git -C "$repo" worktree add -q -b local-name "$renamed"
+git -C "$renamed" update-ref refs/remotes/origin/remote-name HEAD
+git -C "$renamed" branch --set-upstream-to=origin/remote-name local-name >/dev/null
+output=$(run_statusline "$renamed")
+assert_contains "$output" "local-name" "local branch with differently named upstream"
+assert_contains "$output" "https://github.com/example/project/tree/remote-name" "differently named upstream GitHub link"
+assert_not_contains "$output" "https://github.com/example/project/tree/local-name" "local branch name GitHub link"
+printf 'ok - differently named upstream branch\n'
+
+nested="$linked/nested/path"
+mkdir -p "$nested"
+output=$(run_statusline "$nested")
+assert_contains "$output" "feature/linked" "nested linked worktree branch"
+assert_contains "$output" "https://github.com/example/project/tree/feature/linked" "nested linked worktree GitHub link"
+printf 'ok - nested linked worktree directory\n'
+
+local_only="$TMPDIR/local-only"
+git -C "$repo" worktree add -q -b feature/local-only "$local_only"
+output=$(run_statusline "$local_only")
+assert_contains "$output" "feature/local-only" "local-only worktree branch"
+assert_not_contains "$output" "https://github.com/example/project/tree/feature/local-only" "local-only branch GitHub link"
+printf 'ok - local-only worktree branch\n'
+
+git -C "$linked" remote add internal ssh://git@example.com/project.git
+git -C "$linked" update-ref refs/remotes/internal/feature/linked HEAD
+git -C "$linked" branch --set-upstream-to=internal/feature/linked feature/linked >/dev/null
+output=$(run_statusline "$linked")
+assert_contains "$output" "feature/linked" "non-GitHub upstream branch"
+assert_not_contains "$output" "ssh://git@example.com/project.git/tree/feature/linked" "non-GitHub upstream link"
+assert_not_contains "$output" "https://github.com/example/project/tree/feature/linked" "stale GitHub origin link for non-GitHub upstream"
+printf 'ok - non-GitHub upstream\n'
+
+sha=$(git -C "$repo" rev-parse --short HEAD)
+git -C "$repo" checkout -q --detach HEAD
+output=$(run_statusline "$repo")
+assert_contains "$output" "detached@$sha" "detached HEAD label"
+assert_contains "$output" "https://github.com/example/project/tree/$sha" "detached HEAD GitHub link"
+printf 'ok - detached HEAD\n'
+
+nonrepo="$TMPDIR/nonrepo"
+mkdir -p "$nonrepo"
+output=$(run_statusline "$nonrepo")
+assert_not_contains "$output" "detached@" "non-git detached label"
+assert_not_contains "$output" "github.com/example/project" "non-git GitHub link"
+printf 'ok - non-git directory\n'


### PR DESCRIPTION
## Summary
- resolve git refs through Git plumbing so linked worktrees and nested worktree directories show the active worktree ref
- show detached HEADs as `detached@<short-sha>` instead of hiding git state
- make branch links upstream-aware, avoiding broken GitHub links for local-only worktree branches and non-GitHub upstreams
- scope PR/CI lookups to the derived GitHub repo and remote branch ref
- add shell regression coverage for normal repos, linked worktrees, nested worktree dirs, differently named upstream branches, local-only branches, non-GitHub upstreams, detached HEADs, and non-git dirs

## Validation
- `bash -n statusline.sh && bash -n test/git-worktree.sh`
- `./test/git-worktree.sh`
- `git diff --check`
